### PR TITLE
Fix Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM golang:alpine
 ADD . /go/src/leogregianin/brcep
-RUN go install leogregianin/brcep
+RUN cd /go/src/leogregianin/brcep && go install
 CMD ["/go/bin/brcep"]
 EXPOSE 8000


### PR DESCRIPTION
Closes #19

```
% docker build -t brcep .                                                                                                                                   *dockerfile brcep
Sending build context to Docker daemon  1.208MB
Step 1/5 : FROM golang:alpine
 ---> 48260c3da24c
Step 2/5 : ADD . /go/src/leogregianin/brcep
 ---> Using cache
 ---> 706ea6ee1232
Step 3/5 : RUN cd /go/src/leogregianin/brcep && go install
 ---> Using cache
 ---> a3b3fbff9a54
Step 4/5 : CMD ["/go/bin/brcep"]
 ---> Using cache
 ---> e03fcf907640
Step 5/5 : EXPOSE 8000
 ---> Using cache
 ---> 2fb7d7e1c897
Successfully built 2fb7d7e1c897
Successfully tagged brcep:latest
% docker run brcep                                                                                                                                          *dockerfile brcep
   ___.                                  
   \_ |_________   ____  ____ ______     
    | __ \_  __ \_/ ___\/ __ \\____ \    
    | \_\ \  | \/\  \__\  ___/|  |_> >   
    |___  /__|    \___  >___  >   __/    
        \/            \/    \/|__|       
[GIN-debug] [WARNING] Running in "debug" mode. Switch to "release" mode in production.
 - using env:   export GIN_MODE=release
 - using code:  gin.SetMode(gin.ReleaseMode)

[GIN-debug] GET   /:cep/json                --> github.com/leogregianin/brcep/handler.(*CepHandler).Handle-fm (4 handlers)
```
                